### PR TITLE
fix(www) don't source radix-vue version from workspace

### DIFF
--- a/apps/www/.vitepress/theme/utils/codeeditor.ts
+++ b/apps/www/.vitepress/theme/utils/codeeditor.ts
@@ -1,6 +1,5 @@
 import { getParameters } from 'codesandbox/lib/api/define'
 import sdk from '@stackblitz/sdk'
-import { dependencies as deps } from '../../../package.json'
 import { Index as demoIndex } from '../../../../www/__registry__'
 // @ts-expect-error ?raw
 import tailwindConfigRaw from '../../../tailwind.config?raw'
@@ -92,7 +91,7 @@ function constructFiles(componentName: string, style: Style, sources: Record<str
   const iconPackage = style === 'default' ? 'lucide-vue-next' : '@radix-icons/vue'
   const dependencies = {
     'vue': 'latest',
-    'radix-vue': deps['radix-vue'],
+    'radix-vue': 'latest',
     '@radix-ui/colors': 'latest',
     'clsx': 'latest',
     'class-variance-authority': 'latest',


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Workspace is not available in the context of the code editor. This leads to examples failing to start because they try to fetch radix-vue from `catalog:`

### 📸 Screenshots (if appropriate)

![CleanShot 2024-08-01 at 00 11 33@2x](https://github.com/user-attachments/assets/d1afab3e-a462-43b1-b22e-3d3d09a4bbb6)
![CleanShot 2024-08-01 at 00 11 56@2x](https://github.com/user-attachments/assets/95b4b483-d5ae-4b1d-9536-29133b685ae7)


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
